### PR TITLE
Pilot fix: run merge-queue check on pull_request too (unblock queue entry)

### DIFF
--- a/.github/workflows/merge-queue-check.yml
+++ b/.github/workflows/merge-queue-check.yml
@@ -1,5 +1,6 @@
 name: Merge queue check
 on:
+  pull_request:
   merge_group:
 permissions:
   contents: read
@@ -8,7 +9,7 @@ jobs:
     name: verify
     runs-on: ubuntu-latest
     steps:
-      - name: Report merge_group context (trigger + secrets hypothesis)
+      - name: Report context (trigger + secrets hypothesis)
         run: |
           echo "event_name=${{ github.event_name }}"
           echo "actor=${{ github.actor }}"


### PR DESCRIPTION
The merge-queue required check `verify` only triggered on `merge_group`, which deadlocks queue entry (PR head never gets a `verify` status → 'Required status check verify is expected' → can't enqueue). This adds the `pull_request` trigger so `verify` runs on the PR (satisfying queue entry) and again on `merge_group` (inside the queue). Part of the Dependabot merge-queue pilot.