### PR TITLE
Pilot: force a grouped non-major github-actions update

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -28,3 +28,5 @@ updates:
         applies-to: version-updates
         update-types: ["minor", "patch"]
         patterns: ["*"]
+
+# pilot: trigger a version-update run

--- a/.github/workflows/merge-queue-check.yml
+++ b/.github/workflows/merge-queue-check.yml
@@ -16,7 +16,7 @@ jobs:
           echo "ref=${{ github.ref }}"
           echo "PILOT_SECRET populated: ${{ secrets.PILOT_SECRET != '' }}"
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6.0.0
         with:
           node-version: 22.x
           cache: 'npm'


### PR DESCRIPTION
Pins setup-node to v6.0.0 so Dependabot proposes a minor bump that groups into auto-merge-minor-and-patch, to test the genuine auto-merge flow. Touches dependabot.yaml to trigger a run.