### PR TITLE
Pilot: align build.yml setup-node to v6.0.0

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -30,3 +30,5 @@ updates:
         patterns: ["*"]
 
 # pilot: trigger a version-update run
+
+# pilot: trigger run (2)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v6.0.0
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'


### PR DESCRIPTION
So the only setup-node update is a minor bump that groups. Part of the auto-merge test.